### PR TITLE
kots api image uses git sha directly as tag

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -70,7 +70,7 @@ jobs:
           kustomize_version: "2.0.3"
           kustomize_build_dir: "api/kustomize/overlays/kots"
           kustomize_output_file: "kots/api.yaml"
-          kustomize_set_image: "kotsvalidation-api=registry.replicated.com/kots-validation/api:kots-${{ github.sha }}"
+          kustomize_set_image: "kotsvalidation-api=registry.replicated.com/kots-validation/api:${{ github.sha }}"
 
       - name: "kustomize build migrations kots"
         uses: marccampbell/kustomize-github-action@set-image


### PR DESCRIPTION
no prefix